### PR TITLE
Removed: JWTs from persistance storage

### DIFF
--- a/backend/xml-data.md
+++ b/backend/xml-data.md
@@ -80,38 +80,10 @@ Each user will have an entry in the auth file, of which there is only one. The a
     <login>
         <name val="Peter" />
         <hash val="trololol" />
-        <jwts>
-            <jwt>
-                <authorized val="true" />
-                <token_id val="uuid" />
-                <user_id val="userid" />
-                <expiry val="val" />
-            </jwt>
-            <jwt>
-                <authorized val="true" />
-                <token_id val="uuid" />
-                <user_id val="userid" />
-                <expiry val="val" />
-            </jwt>
-        </jwts>
     </login>
     <login>
         <name val="Günther" />
         <hash val="trololol" />
-        <jwts>
-            <jwt>
-                <authorized val="true" />
-                <token_id val="uuid" />
-                <user_id val="userid" />
-                <expiry val="val" />
-            </jwt>
-            <jwt>
-                <authorized val="true" />
-                <token_id val="uuid" />
-                <user_id val="userid" />
-                <expiry val="val" />
-            </jwt>
-        </jwts>
     </login>
 </auth>
 ```


### PR DESCRIPTION
I realized that we DO NOT need to store JWTs in the persistance layer in order to log out. That makes auth a lot more light weight and reduces queries to the DB