### PR TITLE
ID to calendar, owner/user href -> val rename and permission group renames

### DIFF
--- a/backend/xml-data.md
+++ b/backend/xml-data.md
@@ -10,16 +10,16 @@ Descriptions have to be limited to 250 chars (in Frontend and Backend).
 ```xml
 <calendar>
     <name val="Birthday Calendar" />
-    <owner id="ownerName" />
+    <owner val="ownerName" />
     <id val="ownerName/Birthday Calendar" /> <!--this field must always be formed like this and it must be unique -> calendar name must be unique to user-->
     <permissions>
         <view>
-            <user id="Kevin" />
-            <user id="otherkevin" />
+            <user val="Kevin" />
+            <user val="otherkevin" />
         </view>
         <edit>
-            <user id="lol" />
-            <user id="lol2" />
+            <user val="lol" />
+            <user val="lol2" />
         </edit>
     </permissions>
     <items>

--- a/backend/xml-data.md
+++ b/backend/xml-data.md
@@ -10,7 +10,8 @@ Descriptions have to be limited to 250 chars (in Frontend and Backend).
 ```xml
 <calendar>
     <name val="Birthday Calendar" />
-    <owner href="ownerFile1" />
+    <owner val="ownerName" href="ownerFile1" />
+    <id val="ownerName/Birthday Calendar" /> <!--this field must always be formed like this and it must be unique -> calendar name must be unique to user-->
     <permissions>
         <group val="View">
             <user href="Kevin" />

--- a/backend/xml-data.md
+++ b/backend/xml-data.md
@@ -10,15 +10,17 @@ Descriptions have to be limited to 250 chars (in Frontend and Backend).
 ```xml
 <calendar>
     <name val="Birthday Calendar" />
-    <owner val="ownerName" href="ownerFile1" />
+    <owner id="ownerName" />
     <id val="ownerName/Birthday Calendar" /> <!--this field must always be formed like this and it must be unique -> calendar name must be unique to user-->
     <permissions>
-        <group val="View">
-            <user href="Kevin" />
-        </group>
-        <group val="Edit">
-            <user href="lol" />
-        </group>
+        <view>
+            <user id="Kevin" />
+            <user id="otherkevin" />
+        </view>
+        <edit>
+            <user id="lol" />
+            <user id="lol2" />
+        </edit>
     </permissions>
     <items>
         <appointments>


### PR DESCRIPTION
This ID must be formed like the following: `{user_name}/{calendar_name}` . 
I also renamed the href attribute `<owner val="{user_name}">`. (To use a attriute struct in the backend). 
Changed permission groups to be tags in order to easier access them in the backend. 